### PR TITLE
Kellyroach/add playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Adapted from https://github.com/github/gitignore/blob/master/Objective-C.gitignore
+
+# Finder
+.DS_Store
+
+# Xcode
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+

--- a/Arithmosophi.xcodeproj/project.pbxproj
+++ b/Arithmosophi.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C43F37A81C15BCE100C0915D /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = C43F37A71C15BCE100C0915D /* .swiftlint.yml */; };
 		C43F37B11C15C10B00C0915D /* ArithmosophiWatchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = C43F37B01C15C10B00C0915D /* ArithmosophiWatchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C43F37BE1C15C12A00C0915D /* ArithmosophiTVOS.h in Headers */ = {isa = PBXBuildFile; fileRef = C43F37BD1C15C12A00C0915D /* ArithmosophiTVOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C43F37C31C15C13600C0915D /* Arithmosophi.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47004761B304D6900EB0C80 /* Arithmosophi.swift */; };
@@ -38,7 +37,6 @@
 		C496F15E1D496DA7008A2637 /* Sigma.swift in Sources */ = {isa = PBXBuildFile; fileRef = C496F15B1D49648D008A2637 /* Sigma.swift */; };
 		C496F15F1D496DA7008A2637 /* Sigma.swift in Sources */ = {isa = PBXBuildFile; fileRef = C496F15B1D49648D008A2637 /* Sigma.swift */; };
 		C4B1FE7E1D8B45E200B61C97 /* Arithmosophi.h in Headers */ = {isa = PBXBuildFile; fileRef = C470045D1B304CE200EB0C80 /* Arithmosophi.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C4B1FE801D8B45E200B61C97 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = C43F37A71C15BCE100C0915D /* .swiftlint.yml */; };
 		C4B1FE881D8B45F400B61C97 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BD0FB81B32FE8600787E0F /* Box.swift */; };
 		C4B1FE891D8B45F400B61C97 /* Boolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BD0FB51B32FAF400787E0F /* Boolean.swift */; };
 		C4B1FE8A1D8B45F400B61C97 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BD0FB11B32F9E500787E0F /* Optional.swift */; };
@@ -50,6 +48,7 @@
 		C4BD0FAF1B32DF4500787E0F /* Arithmos.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47004861B30530D00EB0C80 /* Arithmos.swift */; };
 		C4BD0FB01B32DF4500787E0F /* Arithmos.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47004861B30530D00EB0C80 /* Arithmos.swift */; };
 		C4E20E001C046774000655FA /* Complex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E20DFE1C046774000655FA /* Complex.swift */; };
+		E1DBFB102133703E0097E66C /* Complex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E20DFE1C046774000655FA /* Complex.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -112,11 +111,12 @@
 		C496F15B1D49648D008A2637 /* Sigma.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sigma.swift; sourceTree = "<group>"; };
 		C4A151901B383EDE00C81C91 /* Parity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parity.swift; sourceTree = "<group>"; };
 		C4B1FE861D8B45E200B61C97 /* ArithmosophiSample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ArithmosophiSample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C4B1FE871D8B45E300B61C97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = /Users/phimage/Dev/Arithmosophi/Samples/Info.plist; sourceTree = "<absolute>"; };
 		C4BD0FB11B32F9E500787E0F /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 		C4BD0FB51B32FAF400787E0F /* Boolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Boolean.swift; sourceTree = "<group>"; };
 		C4BD0FB81B32FE8600787E0F /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		C4E20DFE1C046774000655FA /* Complex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Complex.swift; sourceTree = "<group>"; };
+		E1DBFB11213371310097E66C /* logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = logo.png; sourceTree = "<group>"; };
+		E1DBFB12213371320097E66C /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -167,16 +167,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		C40F9F341B3BFDB600641947 /* Files */ = {
-			isa = PBXGroup;
-			children = (
-				C43F37A71C15BCE100C0915D /* .swiftlint.yml */,
-				C40F9F361B3BFDD300641947 /* Arithmosophi.podspec */,
-				C40F9F351B3BFDC900641947 /* README.md */,
-			);
-			name = Files;
-			sourceTree = "<group>";
-		};
 		C433BBAA1F7618730046D5B1 /* Xcode */ = {
 			isa = PBXGroup;
 			children = (
@@ -209,12 +199,16 @@
 		C470044E1B304CE200EB0C80 = {
 			isa = PBXGroup;
 			children = (
+				C43F37A71C15BCE100C0915D /* .swiftlint.yml */,
+				C40F9F361B3BFDD300641947 /* Arithmosophi.podspec */,
+				E1DBFB12213371320097E66C /* LICENSE */,
+				E1DBFB11213371310097E66C /* logo.png */,
+				C40F9F351B3BFDC900641947 /* README.md */,
 				C4B1FE721D8B3FAD00B61C97 /* Sources */,
 				C4BD0FB31B32FA8400787E0F /* Samples */,
 				C433BBAA1F7618730046D5B1 /* Xcode */,
 				C470049D1B30560700EB0C80 /* Tests */,
 				C47004591B304CE200EB0C80 /* Products */,
-				C40F9F341B3BFDB600641947 /* Files */,
 			);
 			sourceTree = "<group>";
 		};
@@ -235,63 +229,39 @@
 			isa = PBXGroup;
 			children = (
 				C470045D1B304CE200EB0C80 /* Arithmosophi.h */,
-				C470045B1B304CE200EB0C80 /* Supporting Files */,
-			);
-			path = iOS;
-			sourceTree = "<group>";
-		};
-		C470045B1B304CE200EB0C80 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
 				C470045C1B304CE200EB0C80 /* Info.plist */,
 			);
-			name = "Supporting Files";
+			path = iOS;
 			sourceTree = "<group>";
 		};
 		C47004901B30560700EB0C80 /* OSX */ = {
 			isa = PBXGroup;
 			children = (
 				C47004931B30560700EB0C80 /* ArithmosophiOSX.h */,
-				C47004911B30560700EB0C80 /* Supporting Files */,
-			);
-			path = OSX;
-			sourceTree = "<group>";
-		};
-		C47004911B30560700EB0C80 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
 				C47004921B30560700EB0C80 /* Info.plist */,
 			);
-			name = "Supporting Files";
+			path = OSX;
 			sourceTree = "<group>";
 		};
 		C470049D1B30560700EB0C80 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				C470049F1B30560700EB0C80 /* Info.plist */,
 				C47004A01B30560700EB0C80 /* ArithmosophiOSXTests.swift */,
-				C470049E1B30560700EB0C80 /* Supporting Files */,
 			);
 			path = Tests;
-			sourceTree = "<group>";
-		};
-		C470049E1B30560700EB0C80 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				C470049F1B30560700EB0C80 /* Info.plist */,
-			);
-			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
 		C4B1FE721D8B3FAD00B61C97 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				C47004761B304D6900EB0C80 /* Arithmosophi.swift */,
-				C4478C381B31911800194715 /* LogicalOperationsType.swift */,
 				C47004861B30530D00EB0C80 /* Arithmos.swift */,
-				C47004741B304D5600EB0C80 /* Statheros.swift */,
+				C47004761B304D6900EB0C80 /* Arithmosophi.swift */,
+				C4E20DFE1C046774000655FA /* Complex.swift */,
+				C4478C381B31911800194715 /* LogicalOperationsType.swift */,
 				C4687F021B452FB80063EC05 /* MesosOros.swift */,
 				C496F15B1D49648D008A2637 /* Sigma.swift */,
-				C4E20DFE1C046774000655FA /* Complex.swift */,
+				C47004741B304D5600EB0C80 /* Statheros.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -299,13 +269,12 @@
 		C4BD0FB31B32FA8400787E0F /* Samples */ = {
 			isa = PBXGroup;
 			children = (
-				C4B1FE871D8B45E300B61C97 /* Info.plist */,
-				C4BD0FB81B32FE8600787E0F /* Box.swift */,
 				C4BD0FB51B32FAF400787E0F /* Boolean.swift */,
-				C4A151901B383EDE00C81C91 /* Parity.swift */,
-				C4BD0FB11B32F9E500787E0F /* Optional.swift */,
+				C4BD0FB81B32FE8600787E0F /* Box.swift */,
 				C47004841B30514800EB0C80 /* Geometry.swift */,
 				C4478C361B318FFC00194715 /* Geometry+Animation.swift */,
+				C4BD0FB11B32F9E500787E0F /* Optional.swift */,
+				C4A151901B383EDE00C81C91 /* Parity.swift */,
 			);
 			path = Samples;
 			sourceTree = "<group>";
@@ -477,7 +446,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = phimage;
 				TargetAttributes = {
 					C43F37AD1C15C10B00C0915D = {
@@ -543,7 +512,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C43F37A81C15BCE100C0915D /* .swiftlint.yml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -565,7 +533,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C4B1FE801D8B45E200B61C97 /* .swiftlint.yml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -652,6 +619,7 @@
 				C4BD0FB01B32DF4500787E0F /* Arithmos.swift in Sources */,
 				C47004771B304D6900EB0C80 /* Arithmosophi.swift in Sources */,
 				C47004751B304D5600EB0C80 /* Statheros.swift in Sources */,
+				E1DBFB102133703E0097E66C /* Complex.swift in Sources */,
 				C496F15C1D49648D008A2637 /* Sigma.swift in Sources */,
 				C4687F061B4535D00063EC05 /* MesosOros.swift in Sources */,
 				C4478C391B31911800194715 /* LogicalOperationsType.swift in Sources */,
@@ -804,12 +772,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -838,7 +808,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -861,12 +831,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -888,7 +860,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/Arithmosophi.xcodeproj/project.pbxproj
+++ b/Arithmosophi.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		C4BD0FB51B32FAF400787E0F /* Boolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Boolean.swift; sourceTree = "<group>"; };
 		C4BD0FB81B32FE8600787E0F /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		C4E20DFE1C046774000655FA /* Complex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Complex.swift; sourceTree = "<group>"; };
+		E1D4850B213376A0001A3D97 /* Arithmosophi.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Arithmosophi.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		E1DBFB11213371310097E66C /* logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = logo.png; sourceTree = "<group>"; };
 		E1DBFB12213371320097E66C /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -205,6 +206,7 @@
 				E1DBFB11213371310097E66C /* logo.png */,
 				C40F9F351B3BFDC900641947 /* README.md */,
 				C4B1FE721D8B3FAD00B61C97 /* Sources */,
+				E1D4850A21337667001A3D97 /* Playgrounds */,
 				C4BD0FB31B32FA8400787E0F /* Samples */,
 				C433BBAA1F7618730046D5B1 /* Xcode */,
 				C470049D1B30560700EB0C80 /* Tests */,
@@ -277,6 +279,14 @@
 				C4A151901B383EDE00C81C91 /* Parity.swift */,
 			);
 			path = Samples;
+			sourceTree = "<group>";
+		};
+		E1D4850A21337667001A3D97 /* Playgrounds */ = {
+			isa = PBXGroup;
+			children = (
+				E1D4850B213376A0001A3D97 /* Arithmosophi.playground */,
+			);
+			path = Playgrounds;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/Arithmosophi.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Arithmosophi.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Arithmosophi.xcodeproj/xcshareddata/xcschemes/Arithmosophi.xcscheme
+++ b/Arithmosophi.xcodeproj/xcshareddata/xcschemes/Arithmosophi.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -70,7 +69,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Arithmosophi.xcodeproj/xcshareddata/xcschemes/ArithmosophiOSX.xcscheme
+++ b/Arithmosophi.xcodeproj/xcshareddata/xcschemes/ArithmosophiOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -70,7 +70,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Arithmosophi.xcodeproj/xcshareddata/xcschemes/ArithmosophiTVOS.xcscheme
+++ b/Arithmosophi.xcodeproj/xcshareddata/xcschemes/ArithmosophiTVOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Arithmosophi.xcodeproj/xcshareddata/xcschemes/ArithmosophiWatchOS.xcscheme
+++ b/Arithmosophi.xcodeproj/xcshareddata/xcschemes/ArithmosophiWatchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Playgrounds/Arithmosophi.playground/Contents.swift
+++ b/Playgrounds/Arithmosophi.playground/Contents.swift
@@ -1,0 +1,57 @@
+//: ## Arithmosophi
+//: A set of protocols for Arithmetic, Statistics and Logical operations
+import Arithmosophi //  1 + 2 + 3 + 4
+//: ### Arithmosophi.swift
+[1, 2, 3, 4].sum
+[1, 2, 3, 4].product //  1 * 2 * 3 * 4
+["a", "b", "c", "d"].sum // "abcd" same as joinWithSeparator("")
+[["a", "b"], ["c"], ["d"]].sum // ["a","b","c","d"] same as flatMap{$0}
+//: ### Arithmos.swift
+//[abs(-2.0), floor(1.1), ceil(1.1), round(1.1), fract(1.1)]
+[(-2.0).abs(), (1.1).floor(), (1.1).ceil(), (1.1).round(), (1.1).fract()]
+fract(1.1)
+//[sqrt(2.0), cbrt(2.0), pow(2.0, 0.5)]
+[(2.0).sqrt(), (2.0).cbrt(), (2.0).pow(0.5)]
+
+//[exp(1.0), exp2(10.0), log(1.0), log2(1024.0), log10(1000.0), log1p(1.0)]
+[(1.0).exp(), (10.0).exp2(), (1.0).log(), (1024.0).log2(), (1000.0).log10(), (1.0).log1p()]
+//[cos(1.0), sin(1.0), tan(1.0), hypot(3.0, 4.0), 4.0*atan2(1.0, 1.0)]
+[(1.0).cos(), (1.0).sin(), (1.0).tan(), (3.0).hypot(4.0), 4.0*(1.0).atan2(1.0)]
+//[cosh(1.0), sinh(1.0), tanh(1.0)]
+[(1.0).cosh(), (1.0).sinh(), (1.0).tanh()]
+//[asin(0.5), acos(0.1), atan(1.0)]
+[(0.5).asin(), (0.1).acos(), (1.0).atan()]
+[Double.random(4.0), Double.random(1.0, 2.0), Double.random(1.0...2.0)]
+[(1.1).clamp(3.0), (1.1).clamp(2.0, 3.0), (1.1).clamp(2.0...3.0)]
+//: ### LogicalOperationsType.swift
+var truth: Bool = true
+truth &&= false
+truth
+truth ||= true
+truth
+
+//: ### Statheros.swift
+//[cos(Double.π_2), sin(Double.π_2), cos(Double.π), sin(Double.π)]
+[(Double.π_2).cos(), (Double.π_2).sin(), (Double.π).cos(), (Double.π).sin()]
+//[log(Double.e)]
+(Double.e).log()
+//: ### MesosOros.swift
+[1, 2, 3, 4].average //  (1 + 2 + 3 + 4) / 4
+[1, 11, 19, 4, -7].median // 4
+[1.0, 11, 19.5, 4, 12, -7].medianLow // 4
+[1, 11, 19, 4, 12, -7].medianHigh // 11
+//: ### Sigma.swift
+[1.0, 11, 19.5, 4, 12, -7].varianceSample
+[1.0, 11, 19.5, 4, 12, -7].variancePopulation
+[1.0, 11, 19.5, 4, 12, -7].standardDeviationSample
+[1.0, 11, 19.5, 4, 12, -7].standardDeviationPopulation
+[1.0, 11, 19.5, 4, 12, -7].skewness // or .moment.skewness
+[1.0, 11, 19.5, 4, 12, -7].kurtosis // or .moment.kurtosis
+[1, 2, 3.5, 3.7, 8, 12].covarianceSample([0.5, 1, 2.1, 3.4, 3.4, 4])
+[1, 2, 3.5, 3.7, 8, 12].covariancePopulation([0.5, 1, 2.1, 3.4, 3.4, 4])
+[1, 2, 3.5, 3.7, 8, 12].pearson([0.5, 1, 2.1, 3.4, 3.4, 4])
+//: ### Complex.swift
+let complex = Complex<Double>(real: 12.0, imaginary: 9.0)
+complex.description
+let result = complex + 8 // Complex(real: 20, imaginary: 9)
+result.description

--- a/Playgrounds/Arithmosophi.playground/contents.xcplayground
+++ b/Playgrounds/Arithmosophi.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios' display-mode='rendered'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/Playgrounds/Arithmosophi.playground/timeline.xctimeline
+++ b/Playgrounds/Arithmosophi.playground/timeline.xctimeline
@@ -1,0 +1,576 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=37&amp;CharacterRangeLoc=135&amp;EndingColumnNumber=14&amp;EndingLineNumber=4&amp;StartingColumnNumber=4&amp;StartingLineNumber=3&amp;Timestamp=557027283.207906"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=20&amp;CharacterRangeLoc=173&amp;EndingColumnNumber=18&amp;EndingLineNumber=5&amp;StartingColumnNumber=15&amp;StartingLineNumber=4&amp;Timestamp=557027283.208016"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=21&amp;CharacterRangeLoc=212&amp;EndingColumnNumber=19&amp;EndingLineNumber=6&amp;StartingColumnNumber=37&amp;StartingLineNumber=5&amp;Timestamp=557027283.208093"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=27&amp;CharacterRangeLoc=274&amp;EndingColumnNumber=22&amp;EndingLineNumber=7&amp;StartingColumnNumber=60&amp;StartingLineNumber=6&amp;Timestamp=557027283.208165"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=513&amp;CharacterRangeLoc=343&amp;EndingColumnNumber=11&amp;EndingLineNumber=18&amp;StartingColumnNumber=64&amp;StartingLineNumber=7&amp;Timestamp=557027283.2082371"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=58&amp;CharacterRangeLoc=1477&amp;EndingColumnNumber=7&amp;EndingLineNumber=37&amp;StartingColumnNumber=61&amp;StartingLineNumber=34&amp;Timestamp=557027283.20831"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=25&amp;CharacterRangeLoc=1546&amp;EndingColumnNumber=19&amp;EndingLineNumber=38&amp;StartingColumnNumber=18&amp;StartingLineNumber=37&amp;Timestamp=557027283.208391"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=36&amp;CharacterRangeLoc=1588&amp;EndingColumnNumber=27&amp;EndingLineNumber=39&amp;StartingColumnNumber=36&amp;StartingLineNumber=38&amp;Timestamp=557027283.208461"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=16&amp;CharacterRangeLoc=159&amp;EndingColumnNumber=0&amp;EndingLineNumber=5&amp;StartingColumnNumber=1&amp;StartingLineNumber=4&amp;Timestamp=557027283.208534"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=20&amp;CharacterRangeLoc=176&amp;EndingColumnNumber=21&amp;EndingLineNumber=5&amp;StartingColumnNumber=1&amp;StartingLineNumber=5&amp;Timestamp=557027283.208606"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=24&amp;CharacterRangeLoc=215&amp;EndingColumnNumber=25&amp;EndingLineNumber=6&amp;StartingColumnNumber=1&amp;StartingLineNumber=6&amp;Timestamp=557027283.2086771"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=27&amp;CharacterRangeLoc=277&amp;EndingColumnNumber=25&amp;EndingLineNumber=7&amp;StartingColumnNumber=63&amp;StartingLineNumber=6&amp;Timestamp=557027283.208746"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=33&amp;CharacterRangeLoc=836&amp;EndingColumnNumber=24&amp;EndingLineNumber=18&amp;StartingColumnNumber=62&amp;StartingLineNumber=17&amp;Timestamp=557027283.208818"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=60&amp;CharacterRangeLoc=1483&amp;EndingColumnNumber=15&amp;EndingLineNumber=37&amp;StartingColumnNumber=67&amp;StartingLineNumber=34&amp;Timestamp=557027283.208892"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=25&amp;CharacterRangeLoc=1549&amp;EndingColumnNumber=22&amp;EndingLineNumber=38&amp;StartingColumnNumber=21&amp;StartingLineNumber=37&amp;Timestamp=557027283.208961"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=36&amp;CharacterRangeLoc=1591&amp;EndingColumnNumber=30&amp;EndingLineNumber=39&amp;StartingColumnNumber=39&amp;StartingLineNumber=38&amp;Timestamp=557027283.2090369"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=33&amp;CharacterRangeLoc=1650&amp;EndingColumnNumber=13&amp;EndingLineNumber=41&amp;StartingColumnNumber=22&amp;StartingLineNumber=40&amp;Timestamp=557027283.209107"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=41&amp;CharacterRangeLoc=1693&amp;EndingColumnNumber=4&amp;EndingLineNumber=43&amp;StartingColumnNumber=23&amp;StartingLineNumber=41&amp;Timestamp=557027283.20918"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=45&amp;CharacterRangeLoc=1739&amp;EndingColumnNumber=12&amp;EndingLineNumber=44&amp;StartingColumnNumber=9&amp;StartingLineNumber=43&amp;Timestamp=557027283.209253"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=50&amp;CharacterRangeLoc=1790&amp;EndingColumnNumber=22&amp;EndingLineNumber=45&amp;StartingColumnNumber=18&amp;StartingLineNumber=44&amp;Timestamp=557027283.209324"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=54&amp;CharacterRangeLoc=1840&amp;EndingColumnNumber=25&amp;EndingLineNumber=46&amp;StartingColumnNumber=22&amp;StartingLineNumber=45&amp;Timestamp=557027283.209394"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=35&amp;CharacterRangeLoc=1904&amp;EndingColumnNumber=15&amp;EndingLineNumber=47&amp;StartingColumnNumber=35&amp;StartingLineNumber=46&amp;Timestamp=557027283.209464"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=35&amp;CharacterRangeLoc=1961&amp;EndingColumnNumber=13&amp;EndingLineNumber=48&amp;StartingColumnNumber=37&amp;StartingLineNumber=47&amp;Timestamp=557027283.209532"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=72&amp;CharacterRangeLoc=2032&amp;EndingColumnNumber=62&amp;EndingLineNumber=49&amp;StartingColumnNumber=49&amp;StartingLineNumber=48&amp;Timestamp=557027283.209601"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=59&amp;CharacterRangeLoc=2105&amp;EndingColumnNumber=53&amp;EndingLineNumber=50&amp;StartingColumnNumber=63&amp;StartingLineNumber=49&amp;Timestamp=557027283.2096699"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=30&amp;CharacterRangeLoc=280&amp;EndingColumnNumber=31&amp;EndingLineNumber=7&amp;StartingColumnNumber=1&amp;StartingLineNumber=7&amp;Timestamp=557027283.20974"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=90&amp;CharacterRangeLoc=837&amp;EndingColumnNumber=2&amp;EndingLineNumber=19&amp;StartingColumnNumber=63&amp;StartingLineNumber=17&amp;Timestamp=557027283.2098089"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=20&amp;CharacterRangeLoc=1524&amp;EndingColumnNumber=16&amp;EndingLineNumber=37&amp;StartingColumnNumber=13&amp;StartingLineNumber=36&amp;Timestamp=557027283.209884"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=20&amp;CharacterRangeLoc=1552&amp;EndingColumnNumber=20&amp;EndingLineNumber=38&amp;StartingColumnNumber=0&amp;StartingLineNumber=38&amp;Timestamp=557027283.209954"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=33&amp;CharacterRangeLoc=1597&amp;EndingColumnNumber=2&amp;EndingLineNumber=40&amp;StartingColumnNumber=0&amp;StartingLineNumber=39&amp;Timestamp=557027283.210023"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=33&amp;CharacterRangeLoc=1654&amp;EndingColumnNumber=17&amp;EndingLineNumber=41&amp;StartingColumnNumber=26&amp;StartingLineNumber=40&amp;Timestamp=557027283.2100919"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=45&amp;CharacterRangeLoc=1699&amp;EndingColumnNumber=14&amp;EndingLineNumber=43&amp;StartingColumnNumber=29&amp;StartingLineNumber=41&amp;Timestamp=557027283.210193"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=50&amp;CharacterRangeLoc=1745&amp;EndingColumnNumber=23&amp;EndingLineNumber=44&amp;StartingColumnNumber=15&amp;StartingLineNumber=43&amp;Timestamp=557027283.210282"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=50&amp;CharacterRangeLoc=1793&amp;EndingColumnNumber=25&amp;EndingLineNumber=45&amp;StartingColumnNumber=21&amp;StartingLineNumber=44&amp;Timestamp=557027283.210368"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=35&amp;CharacterRangeLoc=1851&amp;EndingColumnNumber=17&amp;EndingLineNumber=46&amp;StartingColumnNumber=33&amp;StartingLineNumber=45&amp;Timestamp=557027283.210479"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=35&amp;CharacterRangeLoc=1910&amp;EndingColumnNumber=21&amp;EndingLineNumber=47&amp;StartingColumnNumber=41&amp;StartingLineNumber=46&amp;Timestamp=557027283.210547"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=35&amp;CharacterRangeLoc=1969&amp;EndingColumnNumber=21&amp;EndingLineNumber=48&amp;StartingColumnNumber=45&amp;StartingLineNumber=47&amp;Timestamp=557027283.210616"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=72&amp;CharacterRangeLoc=2038&amp;EndingColumnNumber=68&amp;EndingLineNumber=49&amp;StartingColumnNumber=55&amp;StartingLineNumber=48&amp;Timestamp=557027283.2106839"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=59&amp;CharacterRangeLoc=2111&amp;EndingColumnNumber=59&amp;EndingLineNumber=50&amp;StartingColumnNumber=0&amp;StartingLineNumber=50&amp;Timestamp=557027283.210758"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=19&amp;CharacterRangeLoc=2330&amp;EndingColumnNumber=5&amp;EndingLineNumber=55&amp;StartingColumnNumber=6&amp;StartingLineNumber=54&amp;Timestamp=557027283.2108279"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=6&amp;CharacterRangeLoc=2275&amp;EndingColumnNumber=15&amp;EndingLineNumber=53&amp;StartingColumnNumber=9&amp;StartingLineNumber=53&amp;Timestamp=557027283.2108999"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=7&amp;CharacterRangeLoc=2197&amp;EndingColumnNumber=20&amp;EndingLineNumber=51&amp;StartingColumnNumber=13&amp;StartingLineNumber=51&amp;Timestamp=557027283.210972"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=7&amp;CharacterRangeLoc=2250&amp;EndingColumnNumber=13&amp;EndingLineNumber=52&amp;StartingColumnNumber=6&amp;StartingLineNumber=52&amp;Timestamp=557027283.211042"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=18&amp;CharacterRangeLoc=2331&amp;EndingColumnNumber=5&amp;EndingLineNumber=55&amp;StartingColumnNumber=7&amp;StartingLineNumber=54&amp;Timestamp=557027283.211109"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=58&amp;CharacterRangeLoc=377&amp;EndingColumnNumber=0&amp;EndingLineNumber=10&amp;StartingColumnNumber=3&amp;StartingLineNumber=9&amp;Timestamp=557027283.211181"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=78&amp;CharacterRangeLoc=474&amp;EndingColumnNumber=32&amp;EndingLineNumber=12&amp;StartingColumnNumber=39&amp;StartingLineNumber=10&amp;Timestamp=557027283.211249"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=125&amp;CharacterRangeLoc=553&amp;EndingColumnNumber=72&amp;EndingLineNumber=15&amp;StartingColumnNumber=33&amp;StartingLineNumber=12&amp;Timestamp=557027283.211318"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=150&amp;CharacterRangeLoc=679&amp;EndingColumnNumber=55&amp;EndingLineNumber=17&amp;StartingColumnNumber=73&amp;StartingLineNumber=15&amp;Timestamp=557027283.211387"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=73&amp;CharacterRangeLoc=436&amp;EndingColumnNumber=0&amp;EndingLineNumber=11&amp;StartingColumnNumber=1&amp;StartingLineNumber=10&amp;Timestamp=557027283.2114559"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=37&amp;CharacterRangeLoc=523&amp;EndingColumnNumber=0&amp;EndingLineNumber=13&amp;StartingColumnNumber=3&amp;StartingLineNumber=12&amp;Timestamp=557027283.211525"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=94&amp;CharacterRangeLoc=613&amp;EndingColumnNumber=25&amp;EndingLineNumber=16&amp;StartingColumnNumber=7&amp;StartingLineNumber=15&amp;Timestamp=557027283.2115951"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=44&amp;CharacterRangeLoc=561&amp;EndingColumnNumber=0&amp;EndingLineNumber=14&amp;StartingColumnNumber=1&amp;StartingLineNumber=13&amp;Timestamp=557027283.211664"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=91&amp;CharacterRangeLoc=687&amp;EndingColumnNumber=4&amp;EndingLineNumber=17&amp;StartingColumnNumber=5&amp;StartingLineNumber=16&amp;Timestamp=557027283.211733"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=79&amp;CharacterRangeLoc=850&amp;EndingColumnNumber=4&amp;EndingLineNumber=19&amp;StartingColumnNumber=5&amp;StartingLineNumber=18&amp;Timestamp=557027283.2118011"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=20&amp;CharacterRangeLoc=1526&amp;EndingColumnNumber=18&amp;EndingLineNumber=37&amp;StartingColumnNumber=15&amp;StartingLineNumber=36&amp;Timestamp=557027283.211869"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=25&amp;CharacterRangeLoc=1571&amp;EndingColumnNumber=44&amp;EndingLineNumber=38&amp;StartingColumnNumber=19&amp;StartingLineNumber=38&amp;Timestamp=557027283.211938"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=36&amp;CharacterRangeLoc=1602&amp;EndingColumnNumber=10&amp;EndingLineNumber=40&amp;StartingColumnNumber=5&amp;StartingLineNumber=39&amp;Timestamp=557027283.212005"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=33&amp;CharacterRangeLoc=1644&amp;EndingColumnNumber=7&amp;EndingLineNumber=41&amp;StartingColumnNumber=16&amp;StartingLineNumber=40&amp;Timestamp=557027283.212074"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=41&amp;CharacterRangeLoc=1704&amp;EndingColumnNumber=15&amp;EndingLineNumber=43&amp;StartingColumnNumber=34&amp;StartingLineNumber=41&amp;Timestamp=557027283.212141"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=45&amp;CharacterRangeLoc=1746&amp;EndingColumnNumber=19&amp;EndingLineNumber=44&amp;StartingColumnNumber=16&amp;StartingLineNumber=43&amp;Timestamp=557027283.2122101"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=50&amp;CharacterRangeLoc=1792&amp;EndingColumnNumber=24&amp;EndingLineNumber=45&amp;StartingColumnNumber=20&amp;StartingLineNumber=44&amp;Timestamp=557027283.212279"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=54&amp;CharacterRangeLoc=1843&amp;EndingColumnNumber=28&amp;EndingLineNumber=46&amp;StartingColumnNumber=25&amp;StartingLineNumber=45&amp;Timestamp=557027283.212346"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=35&amp;CharacterRangeLoc=1898&amp;EndingColumnNumber=9&amp;EndingLineNumber=47&amp;StartingColumnNumber=29&amp;StartingLineNumber=46&amp;Timestamp=557027283.212419"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=35&amp;CharacterRangeLoc=1957&amp;EndingColumnNumber=9&amp;EndingLineNumber=48&amp;StartingColumnNumber=33&amp;StartingLineNumber=47&amp;Timestamp=557027283.21249"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=68&amp;CharacterRangeLoc=2016&amp;EndingColumnNumber=42&amp;EndingLineNumber=49&amp;StartingColumnNumber=33&amp;StartingLineNumber=48&amp;Timestamp=557027283.212558"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=72&amp;CharacterRangeLoc=2085&amp;EndingColumnNumber=46&amp;EndingLineNumber=50&amp;StartingColumnNumber=43&amp;StartingLineNumber=49&amp;Timestamp=557027283.212626"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=59&amp;CharacterRangeLoc=2158&amp;EndingColumnNumber=33&amp;EndingLineNumber=51&amp;StartingColumnNumber=47&amp;StartingLineNumber=50&amp;Timestamp=557027283.212693"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=7&amp;CharacterRangeLoc=2244&amp;EndingColumnNumber=7&amp;EndingLineNumber=52&amp;StartingColumnNumber=0&amp;StartingLineNumber=52&amp;Timestamp=557027283.212761"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=20&amp;CharacterRangeLoc=2297&amp;EndingColumnNumber=51&amp;EndingLineNumber=53&amp;StartingColumnNumber=31&amp;StartingLineNumber=53&amp;Timestamp=557027283.212831"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=19&amp;CharacterRangeLoc=2318&amp;EndingColumnNumber=13&amp;EndingLineNumber=54&amp;StartingColumnNumber=52&amp;StartingLineNumber=53&amp;Timestamp=557027283.2129"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=18&amp;CharacterRangeLoc=2378&amp;EndingColumnNumber=52&amp;EndingLineNumber=55&amp;StartingColumnNumber=34&amp;StartingLineNumber=55&amp;Timestamp=557027283.2129689"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=20&amp;CharacterRangeLoc=2297&amp;EndingColumnNumber=51&amp;EndingLineNumber=53&amp;StartingColumnNumber=31&amp;StartingLineNumber=53&amp;Timestamp=557027283.2130359"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=19&amp;CharacterRangeLoc=2298&amp;EndingColumnNumber=51&amp;EndingLineNumber=53&amp;StartingColumnNumber=32&amp;StartingLineNumber=53&amp;Timestamp=557027283.213105"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=42&amp;CharacterRangeLoc=966&amp;EndingColumnNumber=4&amp;EndingLineNumber=21&amp;StartingColumnNumber=5&amp;StartingLineNumber=20&amp;Timestamp=557027283.213174"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=33&amp;CharacterRangeLoc=932&amp;EndingColumnNumber=4&amp;EndingLineNumber=20&amp;StartingColumnNumber=7&amp;StartingLineNumber=19&amp;Timestamp=557027283.2132421"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=33&amp;CharacterRangeLoc=1011&amp;EndingColumnNumber=4&amp;EndingLineNumber=22&amp;StartingColumnNumber=7&amp;StartingLineNumber=21&amp;Timestamp=557027283.213311"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=42&amp;CharacterRangeLoc=1045&amp;EndingColumnNumber=4&amp;EndingLineNumber=23&amp;StartingColumnNumber=5&amp;StartingLineNumber=22&amp;Timestamp=557027283.213379"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=91&amp;CharacterRangeLoc=1088&amp;EndingColumnNumber=24&amp;EndingLineNumber=24&amp;StartingColumnNumber=5&amp;StartingLineNumber=23&amp;Timestamp=557027283.213461"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=71&amp;CharacterRangeLoc=1084&amp;EndingColumnNumber=0&amp;EndingLineNumber=24&amp;StartingColumnNumber=1&amp;StartingLineNumber=23&amp;Timestamp=557027283.213536"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=65&amp;CharacterRangeLoc=1156&amp;EndingColumnNumber=0&amp;EndingLineNumber=25&amp;StartingColumnNumber=1&amp;StartingLineNumber=24&amp;Timestamp=557027283.213671"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=10&amp;CharacterRangeLoc=510&amp;EndingColumnNumber=0&amp;EndingLineNumber=12&amp;StartingColumnNumber=1&amp;StartingLineNumber=11&amp;Timestamp=557027283.213763"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=64&amp;CharacterRangeLoc=1343&amp;EndingColumnNumber=58&amp;EndingLineNumber=33&amp;StartingColumnNumber=18&amp;StartingLineNumber=32&amp;Timestamp=557027283.2138391"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=64&amp;CharacterRangeLoc=1343&amp;EndingColumnNumber=58&amp;EndingLineNumber=33&amp;StartingColumnNumber=18&amp;StartingLineNumber=32&amp;Timestamp=557027283.2139111"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=76&amp;CharacterRangeLoc=1407&amp;EndingColumnNumber=67&amp;EndingLineNumber=34&amp;StartingColumnNumber=58&amp;StartingLineNumber=33&amp;Timestamp=557027283.21398"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=76&amp;CharacterRangeLoc=1408&amp;EndingColumnNumber=68&amp;EndingLineNumber=34&amp;StartingColumnNumber=59&amp;StartingLineNumber=33&amp;Timestamp=557027283.214049"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=16&amp;CharacterRangeLoc=1503&amp;EndingColumnNumber=8&amp;EndingLineNumber=36&amp;StartingColumnNumber=10&amp;StartingLineNumber=35&amp;Timestamp=557027283.214119"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=5&amp;CharacterRangeLoc=1262&amp;EndingColumnNumber=10&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=557027283.214201"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=5&amp;CharacterRangeLoc=1282&amp;EndingColumnNumber=6&amp;EndingLineNumber=27&amp;StartingColumnNumber=1&amp;StartingLineNumber=27&amp;Timestamp=557027283.214329"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=5&amp;CharacterRangeLoc=1298&amp;EndingColumnNumber=0&amp;EndingLineNumber=29&amp;StartingColumnNumber=1&amp;StartingLineNumber=28&amp;Timestamp=557027283.214398"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=5&amp;CharacterRangeLoc=1304&amp;EndingColumnNumber=6&amp;EndingLineNumber=29&amp;StartingColumnNumber=1&amp;StartingLineNumber=29&amp;Timestamp=557027283.214468"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=5&amp;CharacterRangeLoc=1319&amp;EndingColumnNumber=0&amp;EndingLineNumber=31&amp;StartingColumnNumber=1&amp;StartingLineNumber=30&amp;Timestamp=557027283.214538"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=91&amp;CharacterRangeLoc=683&amp;EndingColumnNumber=0&amp;EndingLineNumber=17&amp;StartingColumnNumber=1&amp;StartingLineNumber=16&amp;Timestamp=557027283.214608"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=79&amp;CharacterRangeLoc=846&amp;EndingColumnNumber=0&amp;EndingLineNumber=19&amp;StartingColumnNumber=1&amp;StartingLineNumber=18&amp;Timestamp=557027283.214676"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=42&amp;CharacterRangeLoc=962&amp;EndingColumnNumber=0&amp;EndingLineNumber=21&amp;StartingColumnNumber=1&amp;StartingLineNumber=20&amp;Timestamp=557027283.214744"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=42&amp;CharacterRangeLoc=1041&amp;EndingColumnNumber=0&amp;EndingLineNumber=23&amp;StartingColumnNumber=1&amp;StartingLineNumber=22&amp;Timestamp=557027283.214811"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=76&amp;CharacterRangeLoc=1417&amp;EndingColumnNumber=0&amp;EndingLineNumber=35&amp;StartingColumnNumber=1&amp;StartingLineNumber=34&amp;Timestamp=557027283.21488"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=16&amp;CharacterRangeLoc=1512&amp;EndingColumnNumber=0&amp;EndingLineNumber=37&amp;StartingColumnNumber=1&amp;StartingLineNumber=36&amp;Timestamp=557027283.214949"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=20&amp;CharacterRangeLoc=1553&amp;EndingColumnNumber=21&amp;EndingLineNumber=38&amp;StartingColumnNumber=1&amp;StartingLineNumber=38&amp;Timestamp=557027283.215018"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=25&amp;CharacterRangeLoc=1598&amp;EndingColumnNumber=26&amp;EndingLineNumber=39&amp;StartingColumnNumber=1&amp;StartingLineNumber=39&amp;Timestamp=557027283.215086"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=36&amp;CharacterRangeLoc=1629&amp;EndingColumnNumber=37&amp;EndingLineNumber=40&amp;StartingColumnNumber=1&amp;StartingLineNumber=40&amp;Timestamp=557027283.21517"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=33&amp;CharacterRangeLoc=1671&amp;EndingColumnNumber=34&amp;EndingLineNumber=41&amp;StartingColumnNumber=1&amp;StartingLineNumber=41&amp;Timestamp=557027283.215248"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=41&amp;CharacterRangeLoc=1731&amp;EndingColumnNumber=0&amp;EndingLineNumber=44&amp;StartingColumnNumber=1&amp;StartingLineNumber=43&amp;Timestamp=557027283.215323"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=45&amp;CharacterRangeLoc=1773&amp;EndingColumnNumber=0&amp;EndingLineNumber=45&amp;StartingColumnNumber=1&amp;StartingLineNumber=44&amp;Timestamp=557027283.215394"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=50&amp;CharacterRangeLoc=1819&amp;EndingColumnNumber=0&amp;EndingLineNumber=46&amp;StartingColumnNumber=1&amp;StartingLineNumber=45&amp;Timestamp=557027283.215469"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=54&amp;CharacterRangeLoc=1870&amp;EndingColumnNumber=0&amp;EndingLineNumber=47&amp;StartingColumnNumber=1&amp;StartingLineNumber=46&amp;Timestamp=557027283.215541"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=35&amp;CharacterRangeLoc=1925&amp;EndingColumnNumber=36&amp;EndingLineNumber=47&amp;StartingColumnNumber=1&amp;StartingLineNumber=47&amp;Timestamp=557027283.215614"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=35&amp;CharacterRangeLoc=1984&amp;EndingColumnNumber=36&amp;EndingLineNumber=48&amp;StartingColumnNumber=1&amp;StartingLineNumber=48&amp;Timestamp=557027283.215687"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=68&amp;CharacterRangeLoc=2043&amp;EndingColumnNumber=0&amp;EndingLineNumber=50&amp;StartingColumnNumber=1&amp;StartingLineNumber=49&amp;Timestamp=557027283.215762"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=72&amp;CharacterRangeLoc=2112&amp;EndingColumnNumber=0&amp;EndingLineNumber=51&amp;StartingColumnNumber=1&amp;StartingLineNumber=50&amp;Timestamp=557027283.215843"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=59&amp;CharacterRangeLoc=2185&amp;EndingColumnNumber=0&amp;EndingLineNumber=52&amp;StartingColumnNumber=1&amp;StartingLineNumber=51&amp;Timestamp=557027283.215922"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=7&amp;CharacterRangeLoc=2271&amp;EndingColumnNumber=12&amp;EndingLineNumber=53&amp;StartingColumnNumber=5&amp;StartingLineNumber=53&amp;Timestamp=557027283.216001"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=19&amp;CharacterRangeLoc=2325&amp;EndingColumnNumber=0&amp;EndingLineNumber=55&amp;StartingColumnNumber=1&amp;StartingLineNumber=54&amp;Timestamp=557027283.216105"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=6&amp;CharacterRangeLoc=2349&amp;EndingColumnNumber=11&amp;EndingLineNumber=55&amp;StartingColumnNumber=5&amp;StartingLineNumber=55&amp;Timestamp=557027283.216187"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "file:///Users/kellyroach/Fork/phimage/Arithmosophi/Playgrounds/Arithmosophi.playground#CharacterRangeLen=18&amp;CharacterRangeLoc=2405&amp;EndingColumnNumber=0&amp;EndingLineNumber=57&amp;StartingColumnNumber=1&amp;StartingLineNumber=56&amp;Timestamp=557027283.216262"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+   </TimelineItems>
+</Timeline>

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ func distance<T: Arithmos>(#x: T, y: T) -> T {
 	return x.hypot(y)
 }
 
-func radiansFromDegrees<T where T: Multiplicable, T:Dividable, T: Arithmos, T: Statheros>(degrees: T) -> T {
+func radiansFromDegrees<T where T: Multiplicable, Dividable, T: Arithmos, T: Statheros>(degrees: T) -> T {
 	return degrees * T.PI / T(180.0)
 }
 ```

--- a/Samples/Box.swift
+++ b/Samples/Box.swift
@@ -27,7 +27,7 @@ SOFTWARE.
 import Foundation
 import Arithmosophi
 
-public final class Box<T> : RawRepresentable where T:Addable, T:Equatable {
+public final class Box<T> : RawRepresentable where T: Addable, T: Equatable {
     public typealias RawValue = T
 
     public var rawValue: T
@@ -44,18 +44,18 @@ public final class Box<T> : RawRepresentable where T:Addable, T:Equatable {
 public func +=<T> (box: inout Box<T>, addend: T) {
     box.rawValue += addend
 }
-public func -=<T> (box: inout Box<T>, addend: T) where T:Substractable {
+public func -=<T> (box: inout Box<T>, addend: T) where T: Substractable {
     box.rawValue -= addend
 }
 
 // Equatable
-extension Box : Equatable {}
+extension Box: Equatable {}
 public func == <T> (lhs: Box<T>, rhs: Box<T>) -> Bool {
     return lhs.rawValue == rhs.rawValue
 }
 
 // Addable
-extension Box : Addable {}
+extension Box: Addable {}
 public func + <T> (lhs: Box<T>, rhs: Box<T>) -> Box<T> {
     return Box(value: lhs.rawValue + rhs.rawValue)
 }

--- a/Samples/Geometry.swift
+++ b/Samples/Geometry.swift
@@ -90,20 +90,20 @@ open class Geometry {
     open class func scale<T: Multiplicable>(dx: T, dy: T, sx: T, sy: T) -> (dx: T, dy: T) { return (dx: dx * sx, dy: dy * sy) }
     open class func scale<T: Multiplicable>(dx: T, dy: T, dz: T, sx: T, sy: T, sz: T) -> (dx: T, dy: T, dz: T) { return (dx: dx * sx, dy: dy * sy, dz: dz * sz) }
 
-    open class func scaleForAspectFit<T>(dxContent: T, dyContent: T, dxArea: T, dyArea: T) -> T where T:Dividable, T:Comparable {
+    open class func scaleForAspectFit<T>(dxContent: T, dyContent: T, dxArea: T, dyArea: T) -> T where T: Dividable, T: Comparable {
         return Swift.min(dxArea / dxContent, dyArea / dyContent)
     }
 
-    open class func scaleForAspectFill<T>(dxContent: T, dyContent: T, dxArea: T, dyArea: T) -> T where T:Dividable, T:Comparable {
+    open class func scaleForAspectFill<T>(dxContent: T, dyContent: T, dxArea: T, dyArea: T) -> T where T: Dividable, T: Comparable {
         return Swift.min(dxArea / dxContent, dyArea / dyContent)
     }
 
-    open class func aspectFit<T>(dxContent: T, dyContent: T, dxArea: T, dyArea: T) -> (dx: T, dy: T) where T:Dividable, T:Multiplicable, T:Comparable {
+    open class func aspectFit<T>(dxContent: T, dyContent: T, dxArea: T, dyArea: T) -> (dx: T, dy: T) where T: Dividable, T: Multiplicable, T: Comparable {
         let s = scaleForAspectFit(dxContent: dxContent, dyContent: dyContent, dxArea: dxArea, dyArea: dyArea)
         return scale(dx: dxContent, dy: dyContent, s: s)
     }
 
-    open class func aspectFill<T>(dxContent: T, dyContent: T, dxArea: T, dyArea: T) -> (dx: T, dy: T) where T:Dividable, T:Multiplicable, T:Comparable {
+    open class func aspectFill<T>(dxContent: T, dyContent: T, dxArea: T, dyArea: T) -> (dx: T, dy: T) where T: Dividable, T: Multiplicable, T: Comparable {
         let s = scaleForAspectFill(dxContent: dxContent, dyContent: dyContent, dxArea: dxArea, dyArea: dyArea)
         return scale(dx: dxContent, dy: dyContent, s: s)
     }

--- a/Sources/Arithmos.swift
+++ b/Sources/Arithmos.swift
@@ -35,6 +35,18 @@ SOFTWARE.
 #endif
 #endif
 
+public func fract(_ x: Double) -> Double {
+    return x - x.floor()
+}
+
+public func fract(_ x: Float) -> Float {
+    return x - x.floor()
+}
+
+public func fract(_ x: CGFloat) -> CGFloat {
+    return x - x.floor()
+}
+
 /// Protocol to add some commons function to Double, CGFloat and Float
 public protocol Arithmos: Comparable {
 
@@ -69,15 +81,17 @@ public protocol Arithmos: Comparable {
     func atan2(_ value: Self) -> Self
     func hypot(_ value: Self) -> Self
 
-    func reciproque() -> Self
+    func reciprocal() -> Self
     func erf() -> Self
     func erfc() -> Self
 
     static func random(_ max: Self) -> Self
-    static func random(_ min: Self, max: Self) -> Self
+    static func random(_ min: Self, _ max: Self) -> Self
+    static func random(_ range: ClosedRange<Self>) -> Self
 
-    func clamp (_ min: Self, _ max: Self) -> Self
-    func clamp (_ range: ClosedRange<Self>) -> Self
+    func clamp(_ max: Self) -> Self
+    func clamp(_ min: Self, _ max: Self) -> Self
+    func clamp(_ range: ClosedRange<Self>) -> Self
 
     init(_ double: Double)
 
@@ -157,24 +171,29 @@ extension Double: Arithmos {
     @_transparent public func atan() -> Double { return Darwin.atan(self) }
     #endif
 
-    @_transparent public func reciproque() -> Double {
+    @_transparent public func reciprocal() -> Double {
         return 1 / self
     }
 
     public static func random(_ max: Double) -> Double {
-        return random(0, max: max)
+        return random(0, max)
     }
-    public static func random(_ min: Double, max: Double) -> Double {
+    public static func random(_ min: Double, _ max: Double) -> Double {
         let diff = max - min
         let rand = Double(arc4random() % (UInt32(RAND_MAX) + 1))
         return ((rand / Double(RAND_MAX)) * diff) + min
     }
-
-    public func clamp (_ min: Double, _ max: Double) -> Double {
-        return Swift.max(min, Swift.min(max, self))
+    public static func random(_ range: ClosedRange<Double>) -> Double {
+        return random(range.lowerBound, range.upperBound)
     }
 
-    public func clamp (_ range: ClosedRange<Double>) -> Double {
+    public func clamp(_ max: Double) -> Double {
+        return clamp(0.0, max)
+    }
+    public func clamp(_ min: Double, _ max: Double) -> Double {
+        return Swift.max(min, Swift.min(max, self))
+    }
+    public func clamp(_ range: ClosedRange<Double>) -> Double {
         return Swift.max(range.lowerBound, Swift.min(range.upperBound, self))
     }
 }
@@ -252,23 +271,29 @@ extension Float: Arithmos {
     @_transparent public func atan() -> Float { return Darwin.atanf(self) }
     #endif
 
-    public func reciproque() -> Float {
+    public func reciprocal() -> Float {
         return 1 / self
     }
+
     public static func random(_ max: Float) -> Float {
-        return random(0, max: max)
+        return random(0, max)
     }
-    public static func random(_ min: Float, max: Float) -> Float {
+    public static func random(_ min: Float, _ max: Float) -> Float {
         let diff = max - min
         let rand = Float(arc4random() % (UInt32(RAND_MAX) + 1))
         return ((rand / Float(RAND_MAX)) * diff) + min
     }
-
-    public func clamp (_ min: Float, _ max: Float) -> Float {
-        return Swift.max(min, Swift.min(max, self))
+    public static func random(_ range: ClosedRange<Float>) -> Float {
+        return random(range.lowerBound, range.upperBound)
     }
 
-    public func clamp (_ range: ClosedRange<Float>) -> Float {
+    public func clamp(_ max: Float) -> Float {
+        return clamp(Float(0.0), max)
+    }
+    public func clamp(_ min: Float, _ max: Float) -> Float {
+        return Swift.max(min, Swift.min(max, self))
+    }
+    public func clamp(_ range: ClosedRange<Float>) -> Float {
         return Swift.max(range.lowerBound, Swift.min(range.upperBound, self))
     }
 }
@@ -310,23 +335,29 @@ extension CGFloat: Arithmos {
     @_transparent public func asin() -> CGFloat { return CoreGraphics.asin(self) }
     @_transparent public func atan() -> CGFloat { return CoreGraphics.atan(self) }
 
-    public func reciproque() -> CGFloat {
+    public func reciprocal() -> CGFloat {
         return 1 / self
     }
+
     public static func random(_ max: CGFloat) -> CGFloat {
-        return random(0, max: max)
+        return random(0, max)
     }
-    public static func random(_ min: CGFloat, max: CGFloat) -> CGFloat {
+    public static func random(_ min: CGFloat, _ max: CGFloat) -> CGFloat {
         let diff = max - min
         let rand = CGFloat(arc4random() % (UInt32(RAND_MAX) + 1))
         return ((rand / CGFloat(RAND_MAX)) * diff) + min
     }
-
-    public func clamp (_ min: CGFloat, _ max: CGFloat) -> CGFloat {
-        return Swift.max(min, Swift.min(max, self))
+    public static func random(_ range: ClosedRange<CGFloat>) -> CGFloat {
+        return random(range.lowerBound, range.upperBound)
     }
 
-    public func clamp (_ range: ClosedRange<CGFloat>) -> CGFloat {
+    public func clamp(_ max: CGFloat) -> CGFloat {
+        return clamp(CGFloat(0.0), max)
+    }
+    public func clamp(_ min: CGFloat, _ max: CGFloat) -> CGFloat {
+        return Swift.max(min, Swift.min(max, self))
+    }
+    public func clamp(_ range: ClosedRange<CGFloat>) -> CGFloat {
         return Swift.max(range.lowerBound, Swift.min(range.upperBound, self))
     }
 }

--- a/Sources/Arithmosophi.swift
+++ b/Sources/Arithmosophi.swift
@@ -75,8 +75,8 @@ public protocol MultiplicableWithOverflow {
     static func &* (lhs: Self, rhs: Self) -> Self
 }
 public protocol Shiftable {
-    static func >> <RHS>(lhs: Self, rhs: RHS) -> Self where RHS : BinaryInteger
-    static func << <RHS>(lhs: Self, rhs: RHS) -> Self where RHS : BinaryInteger
+    static func >> <RHS>(lhs: Self, rhs: RHS) -> Self where RHS: BinaryInteger
+    static func << <RHS>(lhs: Self, rhs: RHS) -> Self where RHS: BinaryInteger
 }
 public protocol XorOperable {
     static func ^ (lhs: Self, rhs: Self) -> Self
@@ -147,7 +147,7 @@ public func += <T> (left: inout [T], right: [T]) {
 }
 
 // lattice impl
-extension Bool : LatticeType {
+extension Bool: LatticeType {
     public static var min: Bool {
         return false
     }
@@ -163,7 +163,7 @@ public func < (left: Bool, right: Bool) -> Bool {
     return left
 }
 
-extension Float : LatticeType {
+extension Float: LatticeType {
     public static var min: Float {
         return .leastNormalMagnitude
     }
@@ -173,7 +173,7 @@ extension Float : LatticeType {
     }
 }
 
-extension Double : LatticeType {
+extension Double: LatticeType {
     public static var min: Double {
         return .leastNormalMagnitude
     }
@@ -183,7 +183,7 @@ extension Double : LatticeType {
     }
 }
 
-extension CGFloat : LatticeType {
+extension CGFloat: LatticeType {
     public static var min: CGFloat {
         return .leastNormalMagnitude
     }

--- a/Sources/Complex.swift
+++ b/Sources/Complex.swift
@@ -80,7 +80,8 @@ public struct Complex<T: ArithmeticType> {
     }
 
     public var description: String {
-        return "\(self.real), \(self.imaginary)i"
+        let zero = T()
+        return self.imaginary < zero ? "\(self.real)-\(-self.imaginary)i" : "\(self.real)+\(self.imaginary)i"
     }
 
     public func map(_ function: (T, T) -> (T, T)) -> Complex<T> {
@@ -204,7 +205,7 @@ public func * <T>(lhs: Complex<T>, rhs: Complex<T>) -> Complex<T> {
     let productOfImaginaries = rhs.imaginary * lhs.imaginary
     let realPart = productOfReals - productOfImaginaries
     let imaginaryPart = ((lhs.real + lhs.imaginary) * (rhs.real + rhs.imaginary)) - productOfReals - productOfImaginaries
-    return Complex(real:realPart, imaginary:imaginaryPart)
+    return Complex(real: realPart, imaginary: imaginaryPart)
 }
 
 // MARK: Dividable
@@ -277,8 +278,7 @@ public protocol Complexable {
         }
 
         public init(complex: ComplexCGFloat) {
-            self.x = complex.real
-            self.y = complex.imaginary
+            self.init(x: complex.real, y: complex.imaginary)
         }
     }
 

--- a/Sources/MesosOros.swift
+++ b/Sources/MesosOros.swift
@@ -67,16 +67,22 @@ public func / (lhs: Int64, rhs: AveragableDivideType) -> Int64 { return lhs / In
 extension UInt: Averagable {}
 public func / (lhs: UInt, rhs: AveragableDivideType) -> UInt { return lhs / UInt(rhs) }
 
-// generic operators on dividable & literal
-public func / <T>(lhs: T, rhs: T.IntegerLiteralType) -> T where T:ExpressibleByIntegerLiteral, T:Dividable {
-    let div: T = T(integerLiteral: rhs)
+// generic operators on dividable & Int & Double
+public protocol ExpressibleByInt {
+    init(_ v: Int)
+}
+public func / <T>(lhs: T, rhs: Int) -> T where T: ExpressibleByInt, T: Dividable {
+    let div: T = T(rhs)
+    return lhs / div
+}
+public protocol ExpressibleByDouble {
+    init(_ v: Double)
+}
+public func / <T>(lhs: T, rhs: Double) -> T where T: ExpressibleByDouble, T: Dividable {
+    let div: T = T(rhs)
     return lhs / div
 }
 
-public func / <T>(lhs: T, rhs: T.FloatLiteralType) -> T where T:ExpressibleByFloatLiteral, T:Dividable {
-    let div: T = T(floatLiteral: rhs)
-    return lhs / div
-}
 // MARK: utility functions
 
 public func averageOf<T: Averagable & Initializable> (_ seq: [T]) -> T {

--- a/Sources/Sigma.swift
+++ b/Sources/Sigma.swift
@@ -277,8 +277,9 @@ public extension Collection where Self.Iterator.Element: Averagable & Initializa
     }
 }
 
-// TODO: percentile
+// MARK: percentile
 // https://en.wikipedia.org/wiki/Percentile
+// NOT IMPLEMENTED YET
 
 // MARK: linear regression
 // https://en.wikipedia.org/wiki/Linear_regression
@@ -315,17 +316,15 @@ public extension Collection where Self.Iterator.Element: Averagable & Initializa
             sum1 = m1 - average * withAverage
             let m2 = multiply(self).average
             sum2 = m2 - average * average
-            break
         case .ols:
             for (element, withElement) in zip(self, with) {
                 let elMinusAverage = (element - average)
                 sum1 += elMinusAverage * (withElement - withAverage)
                 sum2 += elMinusAverage * elMinusAverage
             }
-            break
         }
 
-        let slope = sum1 / sum2 // FIXME Int will failed here by dividing by zero (Int linear regression must return float result)
+        let slope = sum1 / sum2 // ISSUE Int will failed here by dividing by zero (Int linear regression must return float result)
         let intercept = withAverage - slope * average
         return (intercept, slope)
     }

--- a/Tests/ArithmosophiOSXTests.swift
+++ b/Tests/ArithmosophiOSXTests.swift
@@ -209,8 +209,8 @@ class ArithmosophiOSXTests: XCTestCase {
     }
 
     func testMedianHigh_oneItem() {
-        if let result = [8.0].medianHigh {
-            XCTAssertEqual(8.0, result)
+        if let result = [Double(8.0)].medianHigh {
+            XCTAssertEqual(8.0, Double(result))
         } else {
             XCTFail("no result")
         }
@@ -299,7 +299,7 @@ class ArithmosophiOSXTests: XCTestCase {
     }
 
     func testSampleStandardDeviation_whenOne() {
-        let result = [1.0].standardDeviationSample
+        let result = [Double(1.0)].standardDeviationSample
         XCTAssertNil(result)
     }
 
@@ -358,7 +358,7 @@ class ArithmosophiOSXTests: XCTestCase {
     }
 
     func testSampleCovariance_whenGivenSingleSetOfValues() {
-        let result = [1.2].covarianceSample([0.5])
+        let result = [Double(1.2)].covarianceSample([0.5])
 
         XCTAssertNil(result )
     }


### PR DESCRIPTION
This pull request
* Fixes Xcode 9.4.1 compiler warnings and build errors in Arithmosophi
* Adds Arithmosophi.playground, a Swift playground.

Compiler issues are fixed:
* ArithmosophiOSX doesn't build.  6 yellow warning, 4 red build errors.
* Update to recommended settings
* warning: initializer for struct 'CGPoint' must use "self.init(...)" ...
* Unneeded Break in Switch Violation: Avoid using unneeded break statements.
* Expected named member of numeric literal
* Cannot convert value of type 'Int' to expected argument type 'Double'

Arithmosophi.playground: Adds some interactive fun to the the repo.
The Swift playground demos Arithmosophi functionality, is a nice test bed,
and may inspire the viewer to invent and test additional examples.